### PR TITLE
Moved wantsJson from PostObject to Request

### DIFF
--- a/src/App/Lib/MVCCore/Routers/PostObject.php
+++ b/src/App/Lib/MVCCore/Routers/PostObject.php
@@ -87,15 +87,6 @@ class PostObject {
     }
 
     /**
-     * Predicate to check if the post object wants json as a response.
-     *
-     * @return boolean
-     */
-    public function wantsJson(): bool {
-        return isset($_SERVER['HTTP_ACCEPT']) && strpos($_SERVER['HTTP_ACCEPT'], 'application/json') !== false;
-    }
-
-    /**
      * Predicate to check if the post is an ajax request.
      *
      * @return boolean

--- a/src/App/Lib/MVCCore/Routers/Request.php
+++ b/src/App/Lib/MVCCore/Routers/Request.php
@@ -184,4 +184,13 @@ class Request {
         }
         return $queryParams;
     }
+
+    /**
+     * Predicate to check if the post object wants json as a response.
+     *
+     * @return boolean
+     */
+    public function wantsJson(): bool {
+        return isset($_SERVER['HTTP_ACCEPT']) && strpos($_SERVER['HTTP_ACCEPT'], 'application/json') !== false;
+    }
 }


### PR DESCRIPTION
Makes more sense in Request since a get request can also require a json response. PostObject is just for post requests.